### PR TITLE
thf-conference-sample/5517 Atualização dos nomes dos métodos

### DIFF
--- a/thf-conference-api/index.js
+++ b/thf-conference-api/index.js
@@ -27,12 +27,11 @@ swaggerTools.initializeMiddleware(swaggerDoc, function (middleware) {
   app.use(cors({
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
     preflightContinue: false,
-    optionsSuccessStatus: 204,
-    exposedHeaders: ['Date'],
-    credentials: true,
-    origin: '*'
-  }));
-
+		optionsSuccessStatus: 204,
+		credentials: true,
+		origin: '*'
+	}));
+  
   // Interpret Swagger resources and attach metadata to request - must be first in swagger-tools middleware chain
   app.use(middleware.swaggerMetadata());
 

--- a/thf-sample-app-conference/README.md
+++ b/thf-sample-app-conference/README.md
@@ -17,7 +17,7 @@ A seguir, tem-se uma lista de funcionalidades utilizadas no App e onde podem ser
 
 - `ThfSyncService.loadData`: src/app/app.component.ts
 
-- `ThfSyncService.getHttpResponses`: src/app/app.component.ts
+- `ThfSyncService.getResponses`: src/app/app.component.ts
 
 - `ThfSyncService.removeItemOfSync`: src/app/app.component.ts
 

--- a/thf-sample-app-conference/src/app/app.component.ts
+++ b/thf-sample-app-conference/src/app/app.component.ts
@@ -140,10 +140,10 @@ export class MyApp {
   }
 
   private getResponses() {
-    this.thfSync.getHttpResponses().subscribe(thfHttpClientResponse => {
+    this.thfSync.getResponses().subscribe(thfSyncResponse => {
 
-      if (thfHttpClientResponse.response instanceof HttpErrorResponse) {
-        this.thfSync.removeItemOfSync(thfHttpClientResponse.id).then(() => {
+      if (thfSyncResponse.response instanceof HttpErrorResponse) {
+        this.thfSync.removeItemOfSync(thfSyncResponse.id).then(() => {
           this.thfSync.resumeSync();
         });
       }

--- a/thf-sample-app-conference/src/pages/signup/signup.component.ts
+++ b/thf-sample-app-conference/src/pages/signup/signup.component.ts
@@ -37,10 +37,10 @@ export class SignupPage {
   }
 
   private httpCommandEvents() {
-    this.thfSync.getHttpResponses().subscribe(thfHttpClientResponse => {
+    this.thfSync.getResponses().subscribe(thfSyncResponse => {
 
-      if (thfHttpClientResponse.customRequestId === this.signup.username) {
-        const userId = thfHttpClientResponse.response['body'].id;
+      if (thfSyncResponse.customRequestId === this.signup.username) {
+        const userId = thfSyncResponse.response['body'].id;
 
         this.thfStorage.set('login', { userId }).then(() => {
           this.events.publish('user:login');


### PR DESCRIPTION
Foi feita a atualização dos nomes:
- getHttpResponses -> getResponses
- thfHttpClientResponse -> thfSyncResponse

E retirado a exposição do campo 'Date' da API